### PR TITLE
Change name order in buildkite label

### DIFF
--- a/.buildkite/build_pipeline.py
+++ b/.buildkite/build_pipeline.py
@@ -267,8 +267,8 @@ def build_pipeline(steps):
                 cmd,
             ]
 
-            step_conf["label"] = f"({RAY_BRANCH}) " \
-                                 f"{RAY_TEST_BRANCH}/{test_base}: {test_name}"
+            step_conf["label"] = f"{test_name} ({RAY_BRANCH}) - " \
+                                 f"{RAY_TEST_BRANCH}/{test_base}"
             all_steps.append(step_conf)
 
     return all_steps


### PR DESCRIPTION
Currently, it is hard to read the name in the buildkite because it is cut. This PR changes the label name order so that it is more readable without clicking each button. 

<img width="1139" alt="Screen Shot 2021-07-09 at 10 19 44 AM" src="https://user-images.githubusercontent.com/18510752/125114718-2f204d00-e09f-11eb-8d14-827ae596e322.png">
