### PR TITLE
add xgboost_ray master to pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python-dotenv
 expiringdict
 requests
 pytz
+git+https://github.com/ray-project/xgboost_ray.git#xgboost_ray


### PR DESCRIPTION
Tests running on Anyscale Connect require dependencies on Buildkite client. For more context, see https://github.com/ray-project/releaser/issues/26.

**Note:** This will fix the immediate issue, there might be more dependency failures that surface after this one is resolved.