### PR TITLE
Print description in --help

### DIFF
--- a/e2e.py
+++ b/e2e.py
@@ -1630,7 +1630,9 @@ def run_test(test_config_file: str,
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         "--test-config", type=str, required=True, help="Test config file")
     parser.add_argument("--test-name", type=str, help="Test name in config")


### PR DESCRIPTION
Simple tweak to also print the file docstring as `description` argument in argparse, making it appear in terminal when `python e2e.py --help` is called.